### PR TITLE
edge case: handle PEs with unlisted PE machine types

### DIFF
--- a/pe/pe.py
+++ b/pe/pe.py
@@ -416,7 +416,7 @@ class PE(ServiceBase):
             return self.binary.header.machine.name
         except ValueError as v:
             # LIEF python returns actual value of unlisted machine type in the exception message str
-            return hex(str(v).split(' ')[0])
+            return hex(int(str(v).split(' ')[0]))
     
     def add_headers(self):
         # compute PE machine header feature. Called twice


### PR DESCRIPTION
sort of janky because how LIEF python integration handles machine field.
https://github.com/lief-project/LIEF/issues/1170

[NO_TRAIN]::